### PR TITLE
make feed Intent Filters targetted to only feeds

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -53,67 +53,106 @@
             android:name="info.guardianproject.securereaderinterface.AddFeedActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/title_activity_add_feed" >
-            
-			<intent-filter>
-			    <action android:name="android.intent.action.VIEW"/>
-			    <category android:name="android.intent.category.DEFAULT"/>
-			    <category android:name="android.intent.category.BROWSABLE"/>
-			    <data android:scheme="http"/>
-			    <data android:scheme="https"/>
-			    <data android:host="*"/>
-			    <data android:pathPattern=".*\\.xml"/>
-			    <data android:pathPattern=".*\\.rss"/>
-			</intent-filter>
-			
-			<intent-filter>
-			    <action android:name="android.intent.action.VIEW"/>
-			    <category android:name="android.intent.category.DEFAULT"/>
-			    <category android:name="android.intent.category.BROWSABLE"/>
-			    <data android:scheme="http"/>
-			    <data android:scheme="https"/>		
-			    <data android:host="feeds.feedburner.com"/>
-			    <data android:host="feedproxy.google.com"/>
-			    <data android:host="feeds2.feedburner.com"/>
-			    <data android:host="feedsproxy.google.com"/>
-			</intent-filter>
-			
-			<intent-filter>
-			    <action android:name="android.intent.action.VIEW"/>
-			    <category android:name="android.intent.category.DEFAULT"/>
-			    <category android:name="android.intent.category.BROWSABLE"/>
-			    <data android:scheme="http"/>
-			    <data android:scheme="https"/>	
-			    <data android:mimeType="text/*"/>		    
-			    <data android:mimeType="text/xml"/>
-			    <data android:mimeType="application/rss+xml"/>
-			    <data android:mimeType="application/atom+xml"/>
-			    <data android:mimeType="application/xml"/>
-			</intent-filter>         
-			
-			<intent-filter>
-				<action android:name="android.intent.action.SEND" />
-				<category android:name="android.intent.category.DEFAULT" />
-				<category android:name="android.intent.category.ALTERNATIVE" /> 
-				<category android:name="android.intent.category.SELECTED_ALTERNATIVE" /> 
-				<data android:mimeType="text/*" />
-			</intent-filter>
 
-			<!-- 			              
-			<intent-filter>
-			    <action android:name="android.intent.action.VIEW"/>
-			    <category android:name="android.intent.category.DEFAULT"/>
-				<category android:name="android.intent.category.BROWSABLE"/>
-			    <data android:mimeType="text/*"/>
-			</intent-filter>			
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:host="*"/>
+                <data android:pathPrefix="/feed"/>
+                <data android:pathPattern=".*feed/*"/>
+                <!--
+                To match all files with a specific file ending, you have to use this
+                craziness because of Android limitations in their regex parser
+                https://stackoverflow.com/questions/1733195/android-intent-filter-for-a-particular-file-extension
+                https://stackoverflow.com/questions/3400072/pathpattern-to-match-file-extension-does-not-work-if-a-period-exists-elsewhere-i/8599921
+                -->
+                <data android:pathPattern=".*\\.xml"/>
+                <data android:pathPattern=".*\\..*\\.xml"/>
+                <data android:pathPattern=".*\\..*\\..*\\.xml"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xml"/>
+                <data android:pathPattern=".*\\.rss"/>
+                <data android:pathPattern=".*\\..*\\.rss"/>
+                <data android:pathPattern=".*\\..*\\..*\\.rss"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.rss"/>
+            </intent-filter>
 
-			<intent-filter>
-			    <action android:name="android.intent.action.VIEW"/>
-			    <category android:name="android.intent.category.DEFAULT"/>
-			    <category android:name="android.intent.category.BROWSABLE"/>
-			    <data android:scheme="http"/>
-			    <data android:scheme="https"/>
-			</intent-filter>	
-			-->			
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:host="*"/>
+
+                <!--
+                The ultimate in crack smoking!  Some apps will only respect these file associations
+                if the mimeType is not set, and other apps will only respect them if mimeType is set
+                to */*.  Therefore we have two whole copies of the same thing, besides setting the mimeType.
+                -->
+                <data android:mimeType="*/*" />
+
+                <data android:pathPrefix="/feed"/>
+                <data android:pathPattern=".*feed/*"/>
+                <data android:pathPattern=".*\\.xml"/>
+                <data android:pathPattern=".*\\..*\\.xml"/>
+                <data android:pathPattern=".*\\..*\\..*\\.xml"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.xml"/>
+                <data android:pathPattern=".*\\.rss"/>
+                <data android:pathPattern=".*\\..*\\.rss"/>
+                <data android:pathPattern=".*\\..*\\..*\\.rss"/>
+                <data android:pathPattern=".*\\..*\\..*\\..*\\.rss"/>
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:host="feeds.feedburner.com"/>
+                <data android:host="feeds2.feedburner.com"/>
+                <data android:host="feedproxy.google.com"/>
+                <data android:host="feedsproxy.google.com"/>
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:host="*"/>
+                <data android:mimeType="application/atom+xml"/>
+                <data android:mimeType="application/rdf+xml"/>
+                <data android:mimeType="application/rss+xml"/>
+                <data android:mimeType="application/xml"/>
+                <data android:mimeType="text/xml"/>
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="itpc" />
+                <data android:scheme="pcast" />
+                <data android:scheme="feed" />
+                <data android:scheme="rss" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.ALTERNATIVE" />
+                <category android:name="android.intent.category.SELECTED_ALTERNATIVE" />
+                <data android:mimeType="application/atom+xml"/>
+                <data android:mimeType="application/rdf+xml"/>
+                <data android:mimeType="application/rss+xml"/>
+                <data android:mimeType="application/xml"/>
+                <data android:mimeType="text/*"/>
+            </intent-filter>
         </activity>
         <activity
             android:name="info.guardianproject.securereaderinterface.PanicActivity"


### PR DESCRIPTION
This is a set of carefully crafted IntentFilters that set Courier as an option for all the common RSS feed URL types.

    The original IntentFilters made Courier show up as an option for all http
    and https links.  But Courier cannot handle all http/s links.  So for some
    random webpage, the link is placed in the "Add Feed" field, but when you
    click Add, it fails unless its an RSS feed.
    
    This also makes clicking on a proper feed work better since Courier provides
    the only matching pattern, when the pattern is more specific, and therefore
    Courier is the only option, and the process skips the menu to chose which
    app, and instead the feed goes straight into the Add Feed page.
    
    closes https://dev.guardianproject.info/issues/4452
