### PR TITLE
add basic panickit response: lock app on panic trigger

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,6 +161,16 @@
             android:theme="@style/Theme.Transparent" >
         </activity>
         <activity
+            android:name=".PanicResponderActivity"
+            android:launchMode="singleInstance"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="info.guardianproject.panic.action.TRIGGER" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="info.guardianproject.securereaderinterface.ViewMediaActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/title_activity_view_media" >

--- a/app/src/main/java/info/guardianproject/securereaderinterface/PanicResponderActivity.java
+++ b/app/src/main/java/info/guardianproject/securereaderinterface/PanicResponderActivity.java
@@ -1,0 +1,31 @@
+package info.guardianproject.securereaderinterface;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
+
+
+public class PanicResponderActivity extends Activity {
+    private static final String TAG = "PanicResponderActivity";
+
+    public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent();
+        if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+            App.getInstance().socialReader.lockApp();
+            LocalBroadcastManager.getInstance(this).sendBroadcastSync(new Intent(App.EXIT_BROADCAST_ACTION));
+        }
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+    }
+}


### PR DESCRIPTION
This adds the most basic panickit support: a default response that locks
the app when the receives a panic trigger Intent from a panic button app
like our Ripple:
https://play.google.com/store/apps/details?id=info.guardianproject.ripple